### PR TITLE
feat(sitemap): add dynamic city-based blog routes

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,10 +1,18 @@
 import { MetadataRoute } from 'next'
 import { allBlogs } from 'contentlayer/generated'
 import siteMetadata from '@/data/siteMetadata'
+import { setSlug } from 'lib/slug'
 
 export const dynamic = 'force-static'
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export interface City {
+  id: number
+  nama: string
+  latitude: number
+  longitude: number
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const siteUrl = siteMetadata.siteUrl
 
   const blogRoutes = allBlogs
@@ -12,12 +20,37 @@ export default function sitemap(): MetadataRoute.Sitemap {
     .map((post) => ({
       url: `${siteUrl}/${post.path}`,
       lastModified: post.lastmod || post.date,
+      changeFrequency: 'monthly' as const, // Fix: Add 'as const' assertion
+      priority: 0.8,
     }))
 
   const routes = ['', 'blog', 'projects', 'tags'].map((route) => ({
     url: `${siteUrl}/${route}`,
     lastModified: new Date().toISOString().split('T')[0],
+    changeFrequency: 'daily' as const,
+    priority: 0.7,
   }))
 
-  return [...routes, ...blogRoutes]
+  const blogId = async () => {
+    try {
+      const response = await fetch('https://ibnux.github.io/data-indonesia/kota/33.json')
+
+      if (!response.ok) throw new Error('Failed to fetch data')
+      
+      const data = await response.json() as City[]
+      return data.map((city) => ({
+        url: `${siteUrl}/blog/id/jasa-pembuatan-website-murah-di-${setSlug(city.nama)}`,
+        lastModified: new Date().toISOString().split('T')[0],
+        changeFrequency: 'daily' as const,
+        priority: 0.7,
+      }))
+    } catch (error) {
+      console.error(error)
+      return []
+    }
+  }
+
+  const blogIdRoutes = await blogId()
+
+  return [...routes, ...blogRoutes, ...blogIdRoutes]
 }

--- a/lib/slug.ts
+++ b/lib/slug.ts
@@ -1,0 +1,2 @@
+export const setSlug = (text: string): string => 
+    text.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^\w-]/g, '')


### PR DESCRIPTION
Fetch city data from external API and generate blog routes with slugs for each city. This enables location-specific blog URLs for better SEO and user experience.